### PR TITLE
Limit page element insertion to pagination lists.

### DIFF
--- a/BS3/assets/js/datatables.js
+++ b/BS3/assets/js/datatables.js
@@ -85,7 +85,7 @@
 					for ( j=iStart ; j<=iEnd ; j++ ) {
 						sClass = (j==oPaging.iPage+1) ? 'class="active"' : '';
 						$('<li '+sClass+'><a href="#">'+j+'</a></li>')
-							.insertBefore( $('li:last', an[i])[0] )
+							.insertBefore( $(oSettings.sTableId + '_paginate li:last', an[i])[0] )
 							.bind('click', function (e) {
 								e.preventDefault();
 								if ( oSettings.oApi._fnPageChange(oSettings, parseInt($('a', this).text(),10)-1) ) {
@@ -347,7 +347,7 @@
 							$('li:eq(-2)', an[i]).removeClass('disabled');
 						}
 						$(sList)
-							.insertBefore($('li:eq(-2)', an[i]))
+							.insertBefore($(oSettings.sTableId + '_paginate li:eq(-2)', an[i]))
 							.bind('click', function (e) {
 								e.preventDefault();
 								if ( oSettings.oApi._fnPageChange(oSettings, parseInt($('a', this).text(),10)-1) ) {


### PR DESCRIPTION
Insertion of page li elements was not limited to pagination controls for the datatable.  This could cause elements to be inserted elsewhere in the dom.